### PR TITLE
Allow sf stopwatch 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "graphaware/neo4j-php-client": "^4.0@alpha",
         "symfony/event-dispatcher": "^2.7|^3.0",
         "psr/log": "^1.0",
-        "symfony/stopwatch": "^3.0"
+        "symfony/stopwatch": "^2.7|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Not sure if it is 100% right to do, but it allows me to install the reco4php package on Sf 2.8.2.

I looked at the differences in the stopwatch between 2.7.9 and 3.0, and there are literally none, so this should not be a problem - unless the anchoring to version 3.0 was done because of dependencies on other Sf parts ?