### PR TITLE
Fix removal of blacklisted items

### DIFF
--- a/src/Executor/RecommendationExecutor.php
+++ b/src/Executor/RecommendationExecutor.php
@@ -84,9 +84,14 @@ class RecommendationExecutor
     private function removeIrrelevant(Node $input, RecommendationEngine $engine, Recommendations $recommendations, array $blacklist)
     {
         foreach ($recommendations->getItems() as $recommendation) {
-            foreach ($engine->filters() as $filter) {
-                if (!$filter->doInclude($input, $recommendation->item()) || array_key_exists($recommendation->item()->identity(), $blacklist)) {
-                    $recommendations->remove($recommendation);
+            if (array_key_exists($recommendation->item()->identity(), $blacklist)) {
+                $recommendations->remove($recommendation);
+            } else {
+                foreach ($engine->filters() as $filter) {
+                    if (!$filter->doInclude($input, $recommendation->item())) {
+                        $recommendations->remove($recommendation);
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi @ikwattro!

I've noticed that if there are no filters defined, the blacklist doesn't work as it was only executed if at least one Filter is present (I have a recommender with no Filters and one Blacklist). 

I've also noticed that you keep iterating through filters even if item was already removed, and I'm not sure if that's desired behaviour. I've changed both things, please have a look and let me know if it makes sense :)

Thanks, Kacper.