### PR TITLE
Fix getDotProduct

### DIFF
--- a/src/Algorithms/Similarity/CosineSimilarity.php
+++ b/src/Algorithms/Similarity/CosineSimilarity.php
@@ -29,6 +29,7 @@ class CosineSimilarity implements Similarity
     {
         $sum = 0.0;
         foreach ($xVector as $k => $v) {
+            if (!isset($yVector[$k])) continue;
             $sum += (float) ($xVector[$k] * $yVector[$k]);
         }
 


### PR DESCRIPTION
Handle The dot product for 2 distinct vectors 
example : 
```PHP
      $xVector = [
        "item1" => 2,
        "item2" => 2,
        "item3" => 3
      ];

      $yVector = [
        "item1" => 2,
        "item2" => 2
      ];
```